### PR TITLE
Update nameko_sqlalchemy.py

### DIFF
--- a/nameko_sqlalchemy.py
+++ b/nameko_sqlalchemy.py
@@ -22,11 +22,10 @@ class Session(DependencyProvider):
             'service_name': service_name,
             'declarative_base_name': decl_base_name,
         })
+        self.engine = create_engine(self.db_uri)
 
     def get_dependency(self, worker_ctx):
-
-        engine = create_engine(self.db_uri)
-        session_cls = sessionmaker(bind=engine)
+        session_cls = sessionmaker(bind=self.engine)
         session = session_cls()
 
         self.sessions[worker_ctx] = session


### PR DESCRIPTION
base on sqlalchemy document, The typical usage of create_engine() is once per particular database URL, held globally for the lifetime of a single application process.