### PR TITLE
create_engine kwargs fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,8 @@ Pytest fixtures
 Pytest fixtures to allow for easy testing are available.
 
 * ``db_session`` fixture (which depends on ``db_connection`` fixture) will instantiate test database and tear it down at the end of each test.
-* ``model_base`` fixture can be overridden to provide custom ``declarative_base``
+* ``model_base`` fixture can be overridden to provide custom ``declarative_base``.
+* ``create_engine_kwargs`` fixture can be overriden to provide additional keyword arguments to ``sqlalchemy.create_engine``.
 
 .. code-block:: python
 
@@ -70,6 +71,11 @@ Pytest fixtures to allow for easy testing are available.
     @pytest.fixture(scope='session')
     def model_base():
         return DeclarativeBase
+
+
+    @pytest.fixture(scope='session')
+    def create_engine_kwargs():
+        return dict(client_encoding='utf8')
 
 
     def test_users(db_session):

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Pytest fixtures to allow for easy testing are available.
 
 * ``db_session`` fixture (which depends on ``db_connection`` fixture) will instantiate test database and tear it down at the end of each test.
 * ``model_base`` fixture can be overridden to provide custom ``declarative_base``.
-* ``create_engine_kwargs`` fixture can be overriden to provide additional keyword arguments to ``sqlalchemy.create_engine``.
+* ``db_engine_options`` fixture can be overriden to provide additional keyword arguments to ``sqlalchemy.create_engine``.
 
 .. code-block:: python
 
@@ -74,7 +74,7 @@ Pytest fixtures to allow for easy testing are available.
 
 
     @pytest.fixture(scope='session')
-    def create_engine_kwargs():
+    def db_engine_options():
         return dict(client_encoding='utf8')
 
 

--- a/nameko_sqlalchemy/pytest_fixtures.py
+++ b/nameko_sqlalchemy/pytest_fixtures.py
@@ -36,6 +36,24 @@ def db_url(request):
 
 
 @pytest.fixture(scope='session')
+def create_engine_kwargs():
+    """Additional keyword arguments used in sqlalchemy.create_engine.
+
+    http://docs.sqlalchemy.org/en/latest/core/engines.html
+
+    Override this fixture to return a dictionary containing the keyword
+    arguments to be passed to sqlalchemy.create_engine.
+
+    .. code-block:: python
+
+        @pytest.fixture(scope='session')
+        def create_engine_kwargs():
+            return dict(client_encoding='utf8')
+    """
+    return {}
+
+
+@pytest.fixture(scope='session')
 def model_base():
     """Override this fixture to return declarative base of your model
 
@@ -63,8 +81,8 @@ def model_base():
 
 
 @pytest.yield_fixture(scope='session')
-def db_connection(db_url, model_base):
-    engine = create_engine(db_url)
+def db_connection(db_url, model_base, create_engine_kwargs):
+    engine = create_engine(db_url, **create_engine_kwargs)
     model_base.metadata.create_all(engine)
     connection = engine.connect()
     model_base.metadata.bind = engine

--- a/nameko_sqlalchemy/pytest_fixtures.py
+++ b/nameko_sqlalchemy/pytest_fixtures.py
@@ -36,7 +36,7 @@ def db_url(request):
 
 
 @pytest.fixture(scope='session')
-def create_engine_kwargs():
+def db_engine_options():
     """Additional keyword arguments used in sqlalchemy.create_engine.
 
     http://docs.sqlalchemy.org/en/latest/core/engines.html
@@ -47,7 +47,7 @@ def create_engine_kwargs():
     .. code-block:: python
 
         @pytest.fixture(scope='session')
-        def create_engine_kwargs():
+        def db_engine_options():
             return dict(client_encoding='utf8')
     """
     return {}
@@ -81,8 +81,8 @@ def model_base():
 
 
 @pytest.yield_fixture(scope='session')
-def db_connection(db_url, model_base, create_engine_kwargs):
-    engine = create_engine(db_url, **create_engine_kwargs)
+def db_connection(db_url, model_base, db_engine_options):
+    engine = create_engine(db_url, **db_engine_options)
     model_base.metadata.create_all(engine)
     connection = engine.connect()
     model_base.metadata.bind = engine

--- a/test/test_pytest_fixtures.py
+++ b/test/test_pytest_fixtures.py
@@ -39,7 +39,6 @@ def test_db_is_empty(db_session):
 
 
 def test_requires_override_model_base(testdir):
-
     testdir.makepyfile(
         """
         def test_model_base(model_base):
@@ -51,3 +50,67 @@ def test_requires_override_model_base(testdir):
     result.stdout.fnmatch_lines(
         ["*NotImplementedError*"]
     )
+
+
+class TestCreateEngineKwargs(object):
+
+    def test_default_create_engine_kwargs(self, create_engine_kwargs):
+        assert create_engine_kwargs == {}
+
+    def test_create_engine_with_default_kwargs(self, testdir, db_session):
+        testdir.makepyfile(
+            """
+            import pytest
+            from mock import Mock, patch
+
+            @pytest.yield_fixture
+            def create_engine_mock():
+                with patch(
+                    'nameko_sqlalchemy.pytest_fixtures.create_engine'
+                ) as m:
+                    yield m
+
+            @pytest.fixture(scope='session')
+            def model_base():
+                return Mock()
+
+            def test_create_engine_with_default_kwargs(
+                create_engine_mock, db_connection
+            ):
+                kwargs = create_engine_mock.call_args_list[0][1]
+                assert kwargs == {}
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0
+
+    def test_create_engine_with_provided_kwargs(self, testdir, db_session):
+        testdir.makepyfile(
+            """
+            import pytest
+            from mock import Mock, patch
+
+            @pytest.yield_fixture
+            def create_engine_mock():
+                with patch(
+                    'nameko_sqlalchemy.pytest_fixtures.create_engine'
+                ) as m:
+                    yield m
+
+            @pytest.fixture(scope='session')
+            def model_base():
+                return Mock()
+
+            @pytest.fixture(scope='session')
+            def create_engine_kwargs():
+                return dict(client_encoding='utf8')
+
+            def test_create_engine_with_provided_kwargs(
+                create_engine_mock, db_connection
+            ):
+                kwargs = create_engine_mock.call_args_list[0][1]
+                assert kwargs == dict(client_encoding='utf8')
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0

--- a/test/test_pytest_fixtures.py
+++ b/test/test_pytest_fixtures.py
@@ -52,12 +52,12 @@ def test_requires_override_model_base(testdir):
     )
 
 
-class TestCreateEngineKwargs(object):
+class TestDbEngineOptions(object):
 
-    def test_default_create_engine_kwargs(self, create_engine_kwargs):
-        assert create_engine_kwargs == {}
+    def test_default_db_engine_options(self, db_engine_options):
+        assert db_engine_options == {}
 
-    def test_create_engine_with_default_kwargs(self, testdir, db_session):
+    def test_create_engine_with_default_options(self, testdir, db_session):
         testdir.makepyfile(
             """
             import pytest
@@ -74,7 +74,7 @@ class TestCreateEngineKwargs(object):
             def model_base():
                 return Mock()
 
-            def test_create_engine_with_default_kwargs(
+            def test_create_engine_with_default_options(
                 create_engine_mock, db_connection
             ):
                 kwargs = create_engine_mock.call_args_list[0][1]
@@ -84,7 +84,7 @@ class TestCreateEngineKwargs(object):
         result = testdir.runpytest()
         assert result.ret == 0
 
-    def test_create_engine_with_provided_kwargs(self, testdir, db_session):
+    def test_create_engine_with_provided_options(self, testdir, db_session):
         testdir.makepyfile(
             """
             import pytest
@@ -102,10 +102,10 @@ class TestCreateEngineKwargs(object):
                 return Mock()
 
             @pytest.fixture(scope='session')
-            def create_engine_kwargs():
+            def db_engine_options():
                 return dict(client_encoding='utf8')
 
-            def test_create_engine_with_provided_kwargs(
+            def test_create_engine_with_provided_options(
                 create_engine_mock, db_connection
             ):
                 kwargs = create_engine_mock.call_args_list[0][1]


### PR DESCRIPTION
Add `create_engine_kwargs` pytest fixture to provide additional keyword arguments to `sqlalchemy.create_engine`.

At the moment, the DB engine is created inside the `db_connection` fixture with no extra keyword arguments. However, there's often the need to provide extra parameters to `sqlalchemy.create_engine`, and we are forced to override `db_connection` on each service that has this need in order to do so:

```python
@pytest.fixture(scope='session')
def create_engine_kwargs():
    return dict(client_encoding='utf8')


@pytest.yield_fixture(scope='session')
def db_connection(db_url, model_base, create_engine_kwargs):
    engine = create_engine(db_url, **create_engine_kwargs)
    model_base.metadata.create_all(engine)
    connection = engine.connect()
    model_base.metadata.bind = engine

    yield connection

    model_base.metadata.drop_all()
    engine.dispose()
```

With this change, we are trying to avoid having to duplicate `db_connection` on each service that needs additional keyword arguments to create the DB engine, and will be backwards compatible, since `create_engine_kwargs` will return `{}` by default.