### PR TITLE
Support to specify sqlalchemy session options and engine options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - TOX_ENV=py27-test
   - TOX_ENV=py33-test
   - TOX_ENV=py34-test
+  - TOX_ENV=py35-test
+  - TOX_ENV=py36-test
 
 script:
   - tox -e $TOX_ENV

--- a/nameko_sqlalchemy/database_session.py
+++ b/nameko_sqlalchemy/database_session.py
@@ -29,7 +29,7 @@ class DatabaseSession(DependencyProvider):
             'service_name': service_name,
             'declarative_base_name': declarative_base_name,
         })
-        self.engine = create_engine(self.db_uri, config.get(SQL_ALCHEMY_KEY, {}).get(ENGINE_OPTIONS_KEY, {}))
+        self.engine = create_engine(self.db_uri, **config.get(SQL_ALCHEMY_KEY, {}).get(ENGINE_OPTIONS_KEY, {}))
 
     def stop(self):
         self.engine.dispose()

--- a/nameko_sqlalchemy/database_session.py
+++ b/nameko_sqlalchemy/database_session.py
@@ -24,12 +24,15 @@ class DatabaseSession(DependencyProvider):
         uri_key = '{}:{}'.format(service_name, declarative_base_name)
         config = self.container.config
 
-        db_uris = config[SQL_ALCHEMY_KEY][DB_URIS_KEY] if SQL_ALCHEMY_KEY in config else config[DB_URIS_KEY]
+        db_uris = config[SQL_ALCHEMY_KEY][DB_URIS_KEY] \
+            if SQL_ALCHEMY_KEY in config else config[DB_URIS_KEY]
         self.db_uri = db_uris[uri_key].format({
             'service_name': service_name,
             'declarative_base_name': declarative_base_name,
         })
-        self.engine = create_engine(self.db_uri, **config.get(SQL_ALCHEMY_KEY, {}).get(ENGINE_OPTIONS_KEY, {}))
+        self.engine = create_engine(
+            self.db_uri,
+            **config.get(SQL_ALCHEMY_KEY, {}).get(ENGINE_OPTIONS_KEY, {}))
 
     def stop(self):
         self.engine.dispose()

--- a/nameko_sqlalchemy/database_session.py
+++ b/nameko_sqlalchemy/database_session.py
@@ -4,33 +4,39 @@ from nameko.extensions import DependencyProvider
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+SQL_ALCHEMY_KEY = 'SQLALCHEMY'
 DB_URIS_KEY = 'DB_URIS'
+ENGINE_OPTIONS_KEY = 'ENGINE_OPTIONS'
 
 
 class DatabaseSession(DependencyProvider):
-    def __init__(self, declarative_base):
+    def __init__(self, declarative_base, **session_options):
         self.declarative_base = declarative_base
         self.sessions = WeakKeyDictionary()
+        self.session_options = session_options
+
+        self.db_uri = None
+        self.engine = None
 
     def setup(self):
         service_name = self.container.service_name
-        decl_base_name = self.declarative_base.__name__
-        uri_key = '{}:{}'.format(service_name, decl_base_name)
+        declarative_base_name = self.declarative_base.__name__
+        uri_key = '{}:{}'.format(service_name, declarative_base_name)
+        config = self.container.config
 
-        db_uris = self.container.config[DB_URIS_KEY]
+        db_uris = config[SQL_ALCHEMY_KEY][DB_URIS_KEY] if SQL_ALCHEMY_KEY in config else config[DB_URIS_KEY]
         self.db_uri = db_uris[uri_key].format({
             'service_name': service_name,
-            'declarative_base_name': decl_base_name,
+            'declarative_base_name': declarative_base_name,
         })
-        self.engine = create_engine(self.db_uri)
+        self.engine = create_engine(self.db_uri, config.get(SQL_ALCHEMY_KEY, {}).get(ENGINE_OPTIONS_KEY, {}))
 
     def stop(self):
         self.engine.dispose()
         del self.engine
 
     def get_dependency(self, worker_ctx):
-
-        session_cls = sessionmaker(bind=self.engine)
+        session_cls = sessionmaker(bind=self.engine, **self.session_options)
         session = session_cls()
 
         self.sessions[worker_ctx] = session
@@ -39,6 +45,7 @@ class DatabaseSession(DependencyProvider):
     def worker_teardown(self, worker_ctx):
         session = self.sessions.pop(worker_ctx)
         session.close()
+
 
 # backwards compat
 Session = DatabaseSession

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This change add availability to specify session and engine options.
For session options you can add them as kwargs:
```
class TestService:
    db = Session(Base, expire_on_commit=False)
```

For engine options I change the config format to:
```
SQLALCHEMY:
  DB_URIS:
    'test_service:Base': ${DB_URI}
  ENGINE_OPTIONS:
    pool_recycle: 3600
```
Old config format also supported.