### PR TITLE
Clean up database pools in `DatabaseSession.kill()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
       python: 2.7
       env: TOX_ENV=py27
     - stage: test
-      python: 3.3
-      env: TOX_ENV=py33
-    - stage: test
       python: 3.4
       env: TOX_ENV=py34
     - stage: test

--- a/nameko_sqlalchemy/database_session.py
+++ b/nameko_sqlalchemy/database_session.py
@@ -28,6 +28,10 @@ class DatabaseSession(DependencyProvider):
         self.engine.dispose()
         del self.engine
 
+    def kill(self):
+        self.engine.dispose()
+        del self.engine
+
     def get_dependency(self, worker_ctx):
 
         session_cls = sessionmaker(bind=self.engine)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/test/test_database_session.py
+++ b/test/test_database_session.py
@@ -72,6 +72,14 @@ def test_stop(db_session):
     assert not hasattr(db_session, 'engine')
 
 
+def test_kill(db_session):
+    db_session.setup()
+    assert db_session.engine
+
+    db_session.kill()
+    assert not hasattr(db_session, 'engine')
+
+
 def test_get_dependency(db_session):
     db_session.setup()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34,py35,py36}-test
+envlist = {py27,py34,py35,py36}-test
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
We noticed database connections leaking in our test suite:
```
psycopg2.OperationalError: FATAL:  sorry, too many clients already
```
...and got the idea that it had something to do with `ServiceRunner` tear down. It turns out that the associated `runner_factory` test fixture uses `kill()`to clean up the `ServiceRunner` instances which in turn calls `kill()` on the containers and onward to the dependency providers. `DatabaseSession` wasn't disposing its SqlAlchemy connection pool in a timely manner because it was missing an implementation of `kill()`.

@mattbennett actually observed this might be an issue back in August: https://github.com/onefinestay/nameko-sqlalchemy/issues/12