### PR TITLE
Context session closing

### DIFF
--- a/nameko_sqlalchemy/database.py
+++ b/nameko_sqlalchemy/database.py
@@ -12,7 +12,7 @@ DB_URIS_KEY = 'DB_URIS'
 class Session(BaseSession):
 
     def __init__(self, *args, **kwargs):
-        self.close_on_exit = kwargs.pop('close_on_exit', True)
+        self.close_on_exit = kwargs.pop('close_on_exit', False)
         super(Session, self).__init__(*args, **kwargs)
 
     def __enter__(self):
@@ -40,7 +40,7 @@ class DatabaseWrapper(object):
         self._worker_session = None
         self._context_sessions = []
 
-    def get_session(self, close_on_exit=True):
+    def get_session(self, close_on_exit=False):
         session = self.Session(close_on_exit=close_on_exit)
         self._context_sessions.append(session)
         return session

--- a/nameko_sqlalchemy/database.py
+++ b/nameko_sqlalchemy/database.py
@@ -15,11 +15,17 @@ class Session(BaseSession):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type:
-            self.rollback()
-        else:
-            self.commit()
-        self.close()
+        try:
+            if exc_type:
+                self.rollback()
+            else:
+                try:
+                    self.commit()
+                except Exception:
+                    self.rollback()
+                    raise
+        finally:
+            self.close()
 
 
 class DatabaseWrapper(object):

--- a/nameko_sqlalchemy/database.py
+++ b/nameko_sqlalchemy/database.py
@@ -11,6 +11,10 @@ DB_URIS_KEY = 'DB_URIS'
 
 class Session(BaseSession):
 
+    def __init__(self, *args, **kwargs):
+        self.close_on_exit = kwargs.pop('close_on_exit', True)
+        super(Session, self).__init__(*args, **kwargs)
+
     def __enter__(self):
         return self
 
@@ -25,7 +29,8 @@ class Session(BaseSession):
                     self.rollback()
                     raise
         finally:
-            self.close()
+            if self.close_on_exit:
+                self.close()
 
 
 class DatabaseWrapper(object):
@@ -33,9 +38,12 @@ class DatabaseWrapper(object):
     def __init__(self, Session):
         self.Session = Session
         self._worker_session = None
+        self._context_sessions = []
 
-    def get_session(self):
-        return self.Session()
+    def get_session(self, close_on_exit=True):
+        session = self.Session(close_on_exit=close_on_exit)
+        self._context_sessions.append(session)
+        return session
 
     @property
     def session(self):
@@ -46,6 +54,8 @@ class DatabaseWrapper(object):
     def close(self):
         if self._worker_session:
             self._worker_session.close()
+        for session in self._context_sessions:
+            session.close()
 
 
 class Database(DependencyProvider):

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -161,6 +161,22 @@ class TestGetSessionContextManagerUnit:
         rollback.assert_called()
         close.assert_called()
 
+    @patch.object(Session, 'rollback')
+    @patch.object(Session, 'commit')
+    @patch.object(Session, 'close')
+    def test_rolls_back_and_closes_on_commit_error(
+        self, close, commit, rollback, db
+    ):
+
+        commit.side_effect = Exception('Yo!')
+
+        with pytest.raises(Exception):
+            with db.get_session() as session:
+				pass
+
+        rollback.assert_called()
+        close.assert_called()
+
 
 class BaseTestEndToEnd:
 

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -143,9 +143,9 @@ class TestGetSessionContextManagerUnit:
         with db.get_session() as session:
             assert isinstance(session, Session)
 
-        commit.assert_called()
-        rollback.assert_not_called()
-        close.assert_not_called()
+        assert commit.called
+        assert not rollback.called
+        assert not close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -155,9 +155,9 @@ class TestGetSessionContextManagerUnit:
         with db.get_session(close_on_exit=True) as session:
             assert isinstance(session, Session)
 
-        commit.assert_called()
-        rollback.assert_not_called()
-        close.assert_called()
+        assert commit.called
+        assert not rollback.called
+        assert close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -168,9 +168,9 @@ class TestGetSessionContextManagerUnit:
             with db.get_session():
                 raise Exception('Yo!')
 
-        commit.assert_not_called()
-        rollback.assert_called()
-        close.assert_not_called()
+        assert not commit.called
+        assert rollback.called
+        assert not close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -181,9 +181,9 @@ class TestGetSessionContextManagerUnit:
             with db.get_session(close_on_exit=True):
                 raise Exception('Yo!')
 
-        commit.assert_not_called()
-        rollback.assert_called()
-        close.assert_called()
+        assert not commit.called
+        assert rollback.called
+        assert close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -198,8 +198,8 @@ class TestGetSessionContextManagerUnit:
             with db.get_session():
                 pass
 
-        rollback.assert_called()
-        close.assert_not_called()
+        assert rollback.called
+        assert not close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -214,8 +214,8 @@ class TestGetSessionContextManagerUnit:
             with db.get_session(close_on_exit=True):
                 pass
 
-        rollback.assert_called()
-        close.assert_called()
+        assert rollback.called
+        assert close.called
 
     @patch.object(Session, 'rollback')
     @patch.object(Session, 'commit')
@@ -227,16 +227,16 @@ class TestGetSessionContextManagerUnit:
         with db.get_session() as session_one:
             assert isinstance(session_one, Session)
 
-        commit.assert_called()
-        rollback.assert_not_called()
-        close.assert_not_called()
+        assert commit.called
+        assert not rollback.called
+        assert not close.called
 
         with db.get_session(close_on_exit=True) as session_two:
             assert isinstance(session_two, Session)
 
         assert commit.call_count == 2
-        rollback.assert_not_called()
-        close.assert_called()
+        assert not rollback.called
+        assert close.called
 
         assert db._context_sessions == [session_one, session_two]
 

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -250,10 +250,10 @@ class TestGetSessionContextManagerUnit:
         worker_ctx = Mock(spec=WorkerContext)
         db = dependency_provider.get_dependency(worker_ctx)
 
-        with db.get_session(close_on_exit=False) as session_one:
+        with db.get_session(close_on_exit=True) as session_one:
             assert isinstance(session_one, Session)
 
-        with db.get_session() as session_two:
+        with db.get_session(close_on_exit=False) as session_two:
             assert isinstance(session_two, Session)
 
         session_one.add(ExampleModel())


### PR DESCRIPTION
This resolves #24.

Session is not closed at the exit by default, but still gives a choice to do so by passing `close_on_exit=True`. All created sessions are then closed on worker teardown.