### PR TITLE
Add database fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,8 @@ Pytest fixtures to allow for easy testing are available.
 * ``db_session`` fixture (which depends on ``db_connection`` fixture) will instantiate test database and tear it down at the end of each test.
 * ``model_base`` fixture can be overridden to provide custom ``declarative_base``.
 * ``db_engine_options`` fixture can be overriden to provide additional keyword arguments to ``sqlalchemy.create_engine``.
+* ``database`` fixture which is similar to ``db_session`` but can be passed as ``Database`` dependency replacement
+  when using ``worker_factory`` or ``replace_dependencies``.
 
 
 .. code-block:: python

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -3,7 +3,7 @@ from weakref import WeakKeyDictionary
 import pytest
 from mock import Mock, patch
 from nameko.containers import ServiceContainer, WorkerContext
-from nameko.testing.services import dummy, entrypoint_hook
+from nameko.testing.services import dummy, entrypoint_hook, worker_factory
 from nameko_sqlalchemy.database import (
     DB_URIS_KEY,
     Database,
@@ -362,6 +362,13 @@ class TestGetSessionEndToEnd(BaseTestEndToEnd):
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
 
+    def test_database_fixture(self, database):
+
+        service = worker_factory(self.ExampleService, db=database)
+
+        service.write('spam', 'ham')
+        assert service.read('spam') == 'ham'
+
 
 class TestGetSessionContextManagerEndToEnd(BaseTestEndToEnd):
 
@@ -397,6 +404,13 @@ class TestGetSessionContextManagerEndToEnd(BaseTestEndToEnd):
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
 
+    def test_database_fixture(self, database):
+
+        service = worker_factory(self.ExampleService, db=database)
+
+        service.write('spam', 'ham')
+        assert service.read('spam') == 'ham'
+
 
 class TestWorkerScopeSessionEndToEnd(BaseTestEndToEnd):
 
@@ -430,6 +444,13 @@ class TestWorkerScopeSessionEndToEnd(BaseTestEndToEnd):
         # read through the service
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
+
+    def test_database_fixture(self, database):
+
+        service = worker_factory(self.ExampleService, db=database)
+
+        service.write('spam', 'ham')
+        assert service.read('spam') == 'ham'
 
 
 class TestWorkerScopeSessionInContextEndToEnd(BaseTestEndToEnd):
@@ -465,3 +486,10 @@ class TestWorkerScopeSessionInContextEndToEnd(BaseTestEndToEnd):
         # read through the service
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
+
+    def test_database_fixture(self, database):
+
+        service = worker_factory(self.ExampleService, db=database)
+
+        service.write('spam', 'ham')
+        assert service.read('spam') == 'ham'

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -19,8 +19,8 @@ DeclBase = declarative_base(name='examplebase')
 
 class ExampleModel(DeclBase):
     __tablename__ = 'example'
-    key = Column(String(length=16), primary_key=True)
-    value = Column(String(length=16))
+    key = Column(String, primary_key=True)
+    value = Column(String)
 
 
 @pytest.fixture

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -19,8 +19,8 @@ DeclBase = declarative_base(name='examplebase')
 
 class ExampleModel(DeclBase):
     __tablename__ = 'example'
-    key = Column(String, primary_key=True)
-    value = Column(String)
+    key = Column(String(length=16), primary_key=True)
+    value = Column(String(length=16))
 
 
 @pytest.fixture

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -3,7 +3,7 @@ from weakref import WeakKeyDictionary
 import pytest
 from mock import Mock, patch
 from nameko.containers import ServiceContainer, WorkerContext
-from nameko.testing.services import dummy, entrypoint_hook, worker_factory
+from nameko.testing.services import dummy, entrypoint_hook
 from nameko_sqlalchemy.database import (
     DB_URIS_KEY,
     Database,
@@ -306,10 +306,6 @@ class BaseTestEndToEnd:
     def db_uri(self, tmpdir):
         return 'sqlite:///{}'.format(tmpdir.join("db").strpath)
 
-    @pytest.fixture(scope='session')
-    def model_base(self):
-        return DeclBase
-
     @pytest.fixture
     def container(self, container_factory, db_uri):
 
@@ -366,13 +362,6 @@ class TestGetSessionEndToEnd(BaseTestEndToEnd):
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
 
-    def test_database_fixture(self, database):
-
-        service = worker_factory(self.ExampleService, db=database)
-
-        service.write('spam', 'ham')
-        assert service.read('spam') == 'ham'
-
 
 class TestGetSessionContextManagerEndToEnd(BaseTestEndToEnd):
 
@@ -408,13 +397,6 @@ class TestGetSessionContextManagerEndToEnd(BaseTestEndToEnd):
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
 
-    def test_database_fixture(self, database):
-
-        service = worker_factory(self.ExampleService, db=database)
-
-        service.write('spam', 'ham')
-        assert service.read('spam') == 'ham'
-
 
 class TestWorkerScopeSessionEndToEnd(BaseTestEndToEnd):
 
@@ -448,13 +430,6 @@ class TestWorkerScopeSessionEndToEnd(BaseTestEndToEnd):
         # read through the service
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
-
-    def test_database_fixture(self, database):
-
-        service = worker_factory(self.ExampleService, db=database)
-
-        service.write('spam', 'ham')
-        assert service.read('spam') == 'ham'
 
 
 class TestWorkerScopeSessionInContextEndToEnd(BaseTestEndToEnd):
@@ -490,10 +465,3 @@ class TestWorkerScopeSessionInContextEndToEnd(BaseTestEndToEnd):
         # read through the service
         with entrypoint_hook(container, 'read') as read:
             assert read('spam') == 'ham'
-
-    def test_database_fixture(self, database):
-
-        service = worker_factory(self.ExampleService, db=database)
-
-        service.write('spam', 'ham')
-        assert service.read('spam') == 'ham'

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -306,6 +306,10 @@ class BaseTestEndToEnd:
     def db_uri(self, tmpdir):
         return 'sqlite:///{}'.format(tmpdir.join("db").strpath)
 
+    @pytest.fixture(scope='session')
+    def model_base(self):
+        return DeclBase
+
     @pytest.fixture
     def container(self, container_factory, db_uri):
 


### PR DESCRIPTION
Convenient pytest fixture for testing with `Database` dependency provider and using `worker_factory` or `replace_dependencies`.

Resolves #30 